### PR TITLE
Added `gift` member status to `get_members_count` breakdown

### DIFF
--- a/src/aioghost/client.py
+++ b/src/aioghost/client.py
@@ -230,7 +230,7 @@ class GhostAdminAPI:
         """Get member counts from stats endpoint.
 
         Returns:
-            Dict with 'total', 'paid', 'free', 'comped' counts.
+            Dict with 'total', 'paid', 'free', 'comped', 'gift' counts.
         """
         data = await self._get("/ghost/api/admin/members/stats/count/")
 
@@ -244,9 +244,10 @@ class GhostAdminAPI:
                 "paid": latest.get("paid", 0),
                 "free": latest.get("free", 0),
                 "comped": latest.get("comped", 0),
+                "gift": latest.get("gift", 0),
             }
 
-        return {"total": total, "paid": 0, "free": 0, "comped": 0}
+        return {"total": total, "paid": 0, "free": 0, "comped": 0, "gift": 0}
 
     async def get_mrr(self) -> dict[str, int]:
         """Get MRR (Monthly Recurring Revenue) data.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -115,14 +115,15 @@ async def test_get_members_count(api: GhostAdminAPI):
     with aioresponses() as m:
         m.get(
             f"{API_URL}/ghost/api/admin/members/stats/count/",
-            payload={"total": 100, "data": [{"paid": 10, "free": 85, "comped": 5}]},
+            payload={"total": 100, "data": [{"paid": 10, "free": 83, "comped": 5, "gift": 2}]},
         )
         async with api:
             members = await api.get_members_count()
         assert members["total"] == 100
         assert members["paid"] == 10
-        assert members["free"] == 85
+        assert members["free"] == 83
         assert members["comped"] == 5
+        assert members["gift"] == 2
 
 
 @pytest.mark.asyncio
@@ -135,8 +136,12 @@ async def test_get_members_count_empty_history(api: GhostAdminAPI):
         )
         async with api:
             members = await api.get_members_count()
+
         assert members["total"] == 50
         assert members["paid"] == 0
+        assert members["free"] == 0
+        assert members["comped"] == 0
+        assert members["gift"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3509

Added `gift` member status to `get_members_count` breakdown to support members on gift subscriptions